### PR TITLE
refer: print usage to stderr

### DIFF
--- a/refer.c
+++ b/refer.c
@@ -491,7 +491,7 @@ int main(int argc, char *argv[])
 			sortall = (unsigned char) (argv[i][2] ? argv[i][2] : argv[++i][0]);
 			break;
 		default:
-			printf("%s", usage);
+			fprintf(stderr, "%s", usage);
 			return 1;
 		}
 	}


### PR DESCRIPTION
so that if an incorrect option is given in a pipeline, the error message can be seen.